### PR TITLE
Expand PR template with additional branch types

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,14 +9,28 @@ Fixes #
 <!-- Ensure your branch follows the naming convention:
 - `feature/issue-XXX-description` for new features
 - `fix/issue-XXX-description` for bug fixes
-- Example: `feature/issue-42-add-dark-mode` or `fix/issue-15-crash-on-save`
+- `security/issue-XXX-description` for security patches
+- `docs/issue-XXX-description` for documentation updates
+- `refactor/issue-XXX-description` for code refactoring
+- `perf/issue-XXX-description` for performance improvements
+- `chore/issue-XXX-description` for maintenance/dependencies
+- `test/issue-XXX-description` for test improvements
+- `ci/issue-XXX-description` for CI/CD changes
+
+Examples: `feature/issue-42-add-dark-mode`, `fix/issue-15-crash-on-save`, `security/issue-99-xss-prevention`
 -->
 
 ## Type of Change
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
-- [ ] Documentation update
+- [ ] Feature (new functionality)
+- [ ] Bug fix (fixes an issue)
+- [ ] Security patch (security vulnerability fix)
+- [ ] Documentation (docs/README/guides)
+- [ ] Refactor (code improvements without behavior change)
+- [ ] Performance (perf improvements)
+- [ ] Tests (test additions/improvements)
+- [ ] Chore (dependencies, maintenance)
+- [ ] CI/CD (workflow/build configuration)
+- [ ] Breaking change (changes existing behavior)
 
 ## Testing
 - [ ] I have tested these changes locally


### PR DESCRIPTION
Fixes #5

Add support for more branch types in PR template:
- security (security patches)
- docs (documentation updates)  
- refactor (code refactoring)
- perf (performance improvements)
- chore (maintenance/dependencies)
- test (test improvements)
- ci (CI/CD changes)