### PR TITLE
Fix undo history leak and case-sensitive name lookups

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -681,7 +681,7 @@ You are a helpful assistant specializing in [[DOMAIN]].
     // Close mobile drawer
     setMobileDrawerOpen(false);
     // Check if this prompt is already open in a document
-    const existingDoc = documents.find((d) => d.name === prompt.name);
+    const existingDoc = documents.find((d) => d.name.toLowerCase() === prompt.name.toLowerCase());
     if (existingDoc) {
       // Switch to existing document instead of opening a new one
       setActiveDocId(existingDoc.id);
@@ -707,7 +707,7 @@ You are a helpful assistant specializing in [[DOMAIN]].
             message: `Prompt "${prompt.name}" not found. It may have been deleted.`,
           });
           // Remove this prompt from the list immediately
-          setPrompts(prompts.filter((p) => p.name !== prompt.name));
+          setPrompts(prompts.filter((p) => p.name.toLowerCase() !== prompt.name.toLowerCase()));
         } else {
           setAlertModal({
             isOpen: true,
@@ -1045,7 +1045,7 @@ You are a helpful assistant specializing in [[DOMAIN]].
                 console.log('Jump to line:', line);
               }}
               onPromptOpen={async (name) => {
-                const existing = prompts.find((p) => p.name === name);
+                const existing = prompts.find((p) => p.name.toLowerCase() === name.toLowerCase());
                 if (existing) {
                   handlePromptSelect(existing);
                 } else {

--- a/src/components/DocumentProperties.tsx
+++ b/src/components/DocumentProperties.tsx
@@ -44,8 +44,8 @@ const DocumentProperties: React.FC<DocumentPropertiesProps> = ({
     .replace(/[^a-z0-9_-]/g, '');
 
   // Check if the name already exists (excluding current document)
-  const nameExists = !!(normalizedName && normalizedName !== document.name &&
-    allPromptNames.some(name => name.toLowerCase() === normalizedName.toLowerCase()));
+  const nameExists = !!(normalizedName && normalizedName !== document.name.toLowerCase() &&
+    allPromptNames.some(name => name.toLowerCase() === normalizedName));
 
   // Update state when document prop changes
   React.useEffect(() => {

--- a/src/components/EditorPanel.tsx
+++ b/src/components/EditorPanel.tsx
@@ -66,6 +66,12 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
   });
   const [tokenCount, setTokenCount] = useState(0);
 
+  // Reset undo history when switching documents
+  useEffect(() => {
+    setHistory([document.content]);
+    setHistoryIndex(0);
+  }, [document.id]);
+
   // Extract bookmarks from document and update token count
   useEffect(() => {
     try {

--- a/src/utils/__tests__/renderer.additional.test.ts
+++ b/src/utils/__tests__/renderer.additional.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderPrompt, formatXml } from '../renderer'
+
+describe('renderPrompt() - Variable Substitution', () => {
+  const mockFetchPrompt = vi.fn().mockResolvedValue('')
+  const mockFindByTags = vi.fn().mockReturnValue([])
+
+  it('substitutes a single variable', async () => {
+    const result = await renderPrompt(
+      'Hello [[NAME]]',
+      { NAME: 'Alice' },
+      mockFetchPrompt,
+      mockFindByTags
+    )
+    expect(result).toBe('Hello Alice')
+  })
+
+  it('substitutes multiple different variables', async () => {
+    const result = await renderPrompt(
+      '[[GREETING]] [[NAME]]!',
+      { GREETING: 'Hi', NAME: 'Bob' },
+      mockFetchPrompt,
+      mockFindByTags
+    )
+    expect(result).toBe('Hi Bob!')
+  })
+
+  it('substitutes the same variable used multiple times', async () => {
+    const result = await renderPrompt(
+      '[[X]] and [[X]]',
+      { X: 'val' },
+      mockFetchPrompt,
+      mockFindByTags
+    )
+    expect(result).toBe('val and val')
+  })
+
+  it('returns empty string for undefined variable (silent failure)', async () => {
+    const result = await renderPrompt(
+      'Hello [[MISSING]]',
+      {},
+      mockFetchPrompt,
+      mockFindByTags
+    )
+    expect(result).toBe('Hello ')
+  })
+})
+
+describe('renderPrompt() - Comment Stripping', () => {
+  const mockFetchPrompt = vi.fn().mockResolvedValue('')
+  const mockFindByTags = vi.fn().mockReturnValue([])
+
+  it('strips #! single-line comments', async () => {
+    const result = await renderPrompt(
+      '#! this is a comment\nHello',
+      {},
+      mockFetchPrompt,
+      mockFindByTags
+    )
+    expect(result).toBe('Hello')
+  })
+
+  it('strips <!-- --> multiline comments', async () => {
+    const result = await renderPrompt(
+      '<!-- comment -->\nHello',
+      {},
+      mockFetchPrompt,
+      mockFindByTags
+    )
+    expect(result).toBe('Hello')
+  })
+
+  it('strips comments but preserves surrounding content', async () => {
+    const result = await renderPrompt(
+      'Before\n#! comment\nAfter',
+      {},
+      mockFetchPrompt,
+      mockFindByTags
+    )
+    expect(result).toBe('Before\nAfter')
+  })
+})
+
+describe('renderPrompt() - Nested Prompt Injection', () => {
+  const mockFindByTags = vi.fn().mockReturnValue([])
+
+  it('injects a named prompt', async () => {
+    const mockFetch = vi.fn().mockResolvedValue('injected content')
+    const result = await renderPrompt(
+      'Start [[PROMPT: sub]] End',
+      {},
+      mockFetch,
+      mockFindByTags
+    )
+    expect(result).toBe('Start injected content End')
+  })
+
+  it('recursively resolves nested prompts', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce('level1 [[PROMPT: inner]]')
+      .mockResolvedValueOnce('level2')
+    const result = await renderPrompt(
+      '[[PROMPT: outer]]',
+      {},
+      mockFetch,
+      mockFindByTags
+    )
+    expect(result).toBe('level1 level2')
+  })
+
+  it('respects recursive: false option on top-level template', async () => {
+    const mockFetch = vi.fn().mockResolvedValue('')
+    // Template has a variable that would resolve to another sigil
+    const result = await renderPrompt(
+      '[[A]] [[B]]',
+      { A: '[[C]]', B: 'done' },
+      mockFetch,
+      mockFindByTags,
+      undefined,
+      { recursive: false }
+    )
+    // Only one pass, so [[C]] from variable A is not further resolved
+    expect(result).toContain('[[C]]')
+    expect(result).toContain('done')
+  })
+})
+
+describe('renderPrompt() - Variable Hierarchy in Nested Prompts', () => {
+  const mockFindByTags = vi.fn().mockReturnValue([])
+
+  it('passes parent variables to nested prompts', async () => {
+    const mockFetch = vi.fn().mockResolvedValue('Hello [[NAME]]')
+    const result = await renderPrompt(
+      '[[PROMPT: greeting]]',
+      { NAME: 'Alice' },
+      mockFetch,
+      mockFindByTags
+    )
+    expect(result).toBe('Hello Alice')
+  })
+
+  it('prompt variables override parent variables', async () => {
+    const mockFetch = vi.fn().mockResolvedValue('Hello [[NAME]]')
+    const mockGetVars = vi.fn().mockResolvedValue({ NAME: 'Override' })
+    const result = await renderPrompt(
+      '[[PROMPT: greeting]]',
+      { NAME: 'Parent' },
+      mockFetch,
+      mockFindByTags,
+      mockGetVars
+    )
+    expect(result).toBe('Hello Override')
+  })
+})
+
+describe('renderPrompt() - PROMPT_TAG Injection', () => {
+  it('injects prompts matching tags', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce('Content A')
+      .mockResolvedValueOnce('Content B')
+    const mockFindByTags = vi.fn().mockReturnValue(['promptA', 'promptB'])
+
+    const result = await renderPrompt(
+      '[[PROMPT_TAG: persona]]',
+      {},
+      mockFetch,
+      mockFindByTags
+    )
+    expect(mockFindByTags).toHaveBeenCalledWith(['persona'])
+    expect(result).toContain('Content A')
+    expect(result).toContain('Content B')
+  })
+
+  it('respects limit in PROMPT_TAG', async () => {
+    const mockFetch = vi.fn().mockResolvedValue('Content')
+    const mockFindByTags = vi.fn().mockReturnValue(['a', 'b', 'c'])
+
+    await renderPrompt(
+      '[[PROMPT_TAG:2: persona]]',
+      {},
+      mockFetch,
+      mockFindByTags
+    )
+    // Should only fetch 2 prompts
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns empty for no tag matches', async () => {
+    const mockFetch = vi.fn()
+    const mockFindByTags = vi.fn().mockReturnValue([])
+
+    const result = await renderPrompt(
+      '[[PROMPT_TAG: nonexistent]]',
+      {},
+      mockFetch,
+      mockFindByTags
+    )
+    expect(result).toBe('')
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('formatXml()', () => {
+  it('indents nested elements', () => {
+    const result = formatXml('<root><child>text</child></root>')
+    expect(result).toContain('  <child>')
+    expect(result).toContain('    text')
+  })
+
+  it('handles self-closing tags', () => {
+    const result = formatXml('<root><br/></root>')
+    expect(result).toContain('<br/>')
+  })
+
+  it('handles empty input', () => {
+    const result = formatXml('')
+    expect(result).toBe('')
+  })
+
+  it('uses custom indent size', () => {
+    const result = formatXml('<root><child>x</child></root>', 4)
+    expect(result).toContain('    <child>')
+  })
+
+  it('handles comments', () => {
+    const result = formatXml('<root><!-- comment --></root>')
+    expect(result).toContain('<!-- comment -->')
+  })
+})

--- a/src/utils/__tests__/tokenCounter.test.ts
+++ b/src/utils/__tests__/tokenCounter.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { formatTokenCount } from '../tokenCounter'
+
+describe('formatTokenCount()', () => {
+  it('formats small counts as plain number', () => {
+    expect(formatTokenCount(42)).toBe('42 tokens')
+  })
+
+  it('formats counts >= 1000 with k suffix', () => {
+    expect(formatTokenCount(1500)).toBe('1.5k tokens')
+  })
+
+  it('formats exactly 1000', () => {
+    expect(formatTokenCount(1000)).toBe('1.0k tokens')
+  })
+
+  it('formats zero', () => {
+    expect(formatTokenCount(0)).toBe('0 tokens')
+  })
+
+  it('formats large counts', () => {
+    expect(formatTokenCount(128000)).toBe('128.0k tokens')
+  })
+
+  it('formats 999 without k suffix', () => {
+    expect(formatTokenCount(999)).toBe('999 tokens')
+  })
+
+  it('formats fractional k values', () => {
+    expect(formatTokenCount(2345)).toBe('2.3k tokens')
+  })
+})


### PR DESCRIPTION
## Summary
- **Undo history reset**: Added `useEffect` in `EditorPanel` to reset undo `history`/`historyIndex` when `document.id` changes, preventing Cmd+Z from undoing changes across different document tabs
- **Case-insensitive name comparisons**: Normalized all prompt name lookups in `App.tsx` (`handlePromptSelect`, `onPromptOpen`, 404 removal) and `DocumentProperties.tsx` (existence check) to use `.toLowerCase()` so casing differences between user input and stored names don't cause silent failures
- **New tests**: Added 27 tests covering renderer variable substitution, comment stripping, nested prompt injection, variable hierarchy, PROMPT_TAG, `formatXml()`, and `formatTokenCount()`

Closes #35

## Test plan
- [x] All 95 unit tests pass (`npx vitest run`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual: Open two documents, edit both, switch tabs — Cmd+Z only undoes within the active document
- [ ] Manual: Create `[[PROMPT: MyPrompt]]` reference, verify Ctrl+click opens `myprompt` correctly
- [ ] Manual: Rename prompt in DocumentProperties, verify duplicate name detection works regardless of casing